### PR TITLE
Fix live splitting for Ambrose Island moved to H2

### DIFF
--- a/components/livesplit/liveSplitManager.ts
+++ b/components/livesplit/liveSplitManager.ts
@@ -615,9 +615,9 @@ function getCampaignMissions(
             case 1:
                 return trilogy.slice(0, 6)
             case 2:
-                return trilogy.slice(6, 14)
+                return trilogy.slice(6, 15)
             case 3:
-                return trilogy.slice(14, trilogy.length)
+                return trilogy.slice(15, trilogy.length)
             default:
                 return trilogy
         }


### PR DESCRIPTION
## Scope

I have fixed the functionality of the livesplitter for the Ambrose Island mission following its transition to Hitman 2.

## Checklist

-   [x] I have run Prettier to reformat any changed files
-   [x] I have verified my changes work